### PR TITLE
Add online PTT2 to Hugo exporter

### DIFF
--- a/.github/workflows/ptt2-export.yml
+++ b/.github/workflows/ptt2-export.yml
@@ -21,6 +21,16 @@ on:
           - both
           - posts
           - essence
+      max_posts:
+        description: "Newest regular posts (0 = all)"
+        required: true
+        default: "0"
+        type: string
+      max_essence_documents:
+        description: "Essence documents (0 = all)"
+        required: true
+        default: "0"
+        type: string
 
 permissions:
   contents: read
@@ -30,10 +40,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  probe:
-    name: Probe PTT2 and InAddition
+  validate:
+    name: Validate exporter
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: tools/ptt2-exporter/requirements.txt
+
+      - name: Install PTT2 client
+        run: python -m pip install -r tools/ptt2-exporter/requirements.txt
+
+      - name: Compile and run offline tests
+        run: |
+          python -m compileall -q tools/ptt2-exporter
+          python -m unittest discover -s tools/ptt2-exporter/tests -v
+
+  export:
+    name: Export PTT2 bundle
+    if: github.event_name == 'workflow_dispatch'
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
     env:
       PTT2_ID: ${{ secrets.PTT2_ID }}
       PTT2_PASSWORD: ${{ secrets.PTT2_PASSWORD }}
@@ -49,17 +82,24 @@ jobs:
       - name: Install PTT2 client
         run: python -m pip install -r tools/ptt2-exporter/requirements.txt
 
-      - name: Probe board and essence root
+      - name: Export board
         env:
-          BOARD: ${{ github.event_name == 'workflow_dispatch' && inputs.board || 'InAddition' }}
-        run: python tools/ptt2-exporter/ptt2_probe.py --board "$BOARD"
+          BOARD: ${{ inputs.board }}
+          SCOPE: ${{ inputs.scope }}
+          MAX_POSTS: ${{ inputs.max_posts }}
+          MAX_ESSENCE_DOCUMENTS: ${{ inputs.max_essence_documents }}
+        run: |
+          python tools/ptt2-exporter/ptt2_export.py \
+            --board "$BOARD" \
+            --scope "$SCOPE" \
+            --max-posts "$MAX_POSTS" \
+            --max-essence-documents "$MAX_ESSENCE_DOCUMENTS" \
+            --output ptt2-export
 
-      - name: Upload sanitized probe report
-        if: always()
+      - name: Upload Hugo-ready ZIP
         uses: actions/upload-artifact@v4
         with:
-          name: ptt2-probe-${{ github.run_id }}
-          path: ptt2-probe.json
-          if-no-files-found: warn
-          retention-days: 7
-
+          name: ptt2-${{ inputs.board }}-${{ github.run_id }}
+          path: ptt2-export.zip
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/ptt2-export.yml
+++ b/.github/workflows/ptt2-export.yml
@@ -1,0 +1,65 @@
+name: Export PTT2 board
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/ptt2-export.yml"
+      - "tools/ptt2-exporter/**"
+  workflow_dispatch:
+    inputs:
+      board:
+        description: "PTT2 board name"
+        required: true
+        default: "InAddition"
+        type: string
+      scope:
+        description: "Content to export"
+        required: true
+        default: "both"
+        type: choice
+        options:
+          - both
+          - posts
+          - essence
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "ptt2-export-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    name: Probe PTT2 and InAddition
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PTT2_ID: ${{ secrets.PTT2_ID }}
+      PTT2_PASSWORD: ${{ secrets.PTT2_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: tools/ptt2-exporter/requirements.txt
+
+      - name: Install PTT2 client
+        run: python -m pip install -r tools/ptt2-exporter/requirements.txt
+
+      - name: Probe board and essence root
+        env:
+          BOARD: ${{ github.event_name == 'workflow_dispatch' && inputs.board || 'InAddition' }}
+        run: python tools/ptt2-exporter/ptt2_probe.py --board "$BOARD"
+
+      - name: Upload sanitized probe report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ptt2-probe-${{ github.run_id }}
+          path: ptt2-probe.json
+          if-no-files-found: warn
+          retention-days: 7
+

--- a/tools/ptt2-exporter/README.md
+++ b/tools/ptt2-exporter/README.md
@@ -1,19 +1,62 @@
-# PTT2 to Hugo exporter
+# PTT2 → Hugo 匯出器
 
-This directory contains a read-only importer for public PTT2 boards. The first
-target board is `InAddition`.
+這是一個唯讀工具，用來匯出 PTT2 公開看板的一般文章與 `z` 精華區，並打包成
+可供本站（Hugo + PaperMod）審稿的 ZIP。預設看板是 `InAddition`。
 
-The initial probe verifies three things before the full importer is enabled:
+## 線上使用
 
-1. a GitHub-hosted runner can reach PTT2 over WebSocket;
-2. guest access can read the public board and its article list;
-3. the board's `z` (essence/man) root screen can be parsed reliably.
+1. 到 GitHub repository 的 **Actions** 頁面。
+2. 選擇 **Export PTT2 board** → **Run workflow**。
+3. 輸入看板名稱；`scope` 可選全部、一般文章或精華區。
+4. `max_posts` 與 `max_essence_documents` 填 `0` 代表全部，填正整數可先小量測試。
+5. 執行完成後，在該次 workflow run 的 **Artifacts** 下載 ZIP。
 
-Credentials are optional. The probe uses `guest` by default. If PTT2 requires
-a registered account, set `PTT2_ID` and `PTT2_PASSWORD` as repository secrets;
-never commit credentials.
+PTT2 的匿名訪客有同時上線人數限制。工具會自動重試 guest 登入；如果仍遇到
+`guest capacity is full`，可稍後重跑，或在 repository 的
+**Settings → Secrets and variables → Actions** 建立：
 
-The completed exporter will produce a ZIP rooted at `content/posts/ptt2/` plus
-an import manifest, so it can be copied into this Hugo repository or reviewed
-through a draft pull request before publication.
+- `PTT2_ID`
+- `PTT2_PASSWORD`
 
+帳密只會由 GitHub Actions 在執行期間讀取，不要把帳密寫進程式、issue、PR 或聊天內容。
+
+## ZIP 內容
+
+```text
+content/posts/ptt2/<board>/          Hugo 一般文章草稿
+content/posts/ptt2/<board>/essence/  Hugo 精華區草稿
+ptt2-archive/<board>/                去除 IP 後的結構化 JSON 原始備份
+manifest.json                        數量、錯誤與每個 Markdown 的 SHA-256
+```
+
+所有 Hugo 檔案一律設定 `draft = true`。確認作者、內容、授權與版面後，再把要發布的
+檔案複製到 repository 的 `content/posts/` 並改成 `draft = false`。
+
+匯出檔刻意不保存文章與推文 IP。PTT 的純文字與 ASCII art 放在 Markdown code fence
+內，避免被 Hugo 誤判成標題、短代碼或 HTML。
+
+## 本機使用
+
+需要 Python 3.11 以上：
+
+```bash
+python -m pip install -r tools/ptt2-exporter/requirements.txt
+python tools/ptt2-exporter/ptt2_export.py \
+  --board InAddition \
+  --scope both \
+  --max-posts 0 \
+  --max-essence-documents 0
+```
+
+需要註冊帳號時，透過環境變數 `PTT2_ID`、`PTT2_PASSWORD` 傳入。匯出器只有讀取
+流程，不會發文、推文、寄信或變更看板。
+
+## 測試
+
+```bash
+python -m unittest discover -s tools/ptt2-exporter/tests -v
+```
+
+一般文章使用 PyPtt 的公開讀取 API；精華區因 PyPtt 沒有對應的高階 API，使用
+VT100 畫面的狀態機遞迴導覽。若 PTT2 日後更改精華區畫面格式，離線 parser 測試會
+保留目前支援的格式，實際匯出錯誤則會出現在 Actions log。

--- a/tools/ptt2-exporter/README.md
+++ b/tools/ptt2-exporter/README.md
@@ -1,0 +1,19 @@
+# PTT2 to Hugo exporter
+
+This directory contains a read-only importer for public PTT2 boards. The first
+target board is `InAddition`.
+
+The initial probe verifies three things before the full importer is enabled:
+
+1. a GitHub-hosted runner can reach PTT2 over WebSocket;
+2. guest access can read the public board and its article list;
+3. the board's `z` (essence/man) root screen can be parsed reliably.
+
+Credentials are optional. The probe uses `guest` by default. If PTT2 requires
+a registered account, set `PTT2_ID` and `PTT2_PASSWORD` as repository secrets;
+never commit credentials.
+
+The completed exporter will produce a ZIP rooted at `content/posts/ptt2/` plus
+an import manifest, so it can be copied into this Hugo repository or reviewed
+through a draft pull request before publication.
+

--- a/tools/ptt2-exporter/essence.py
+++ b/tools/ptt2-exporter/essence.py
@@ -1,0 +1,214 @@
+"""Recursive reader for PTT2's terminal-only z/essence tree."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from PyPtt import _api_util, command, connect_core, screens
+
+
+MENU_ROW_RE = re.compile(
+    r"^\s*(?:>|●)?\s*(\d+)[.)]\s*([◆◇◎●○□■★]?)\s*(.*?)\s*$"
+)
+MENU_WORDS = ("精華區", "精華文章", "目錄")
+
+
+@dataclass(frozen=True)
+class MenuEntry:
+    index: int
+    marker: str
+    title: str
+
+
+@dataclass(frozen=True)
+class EssenceDocument:
+    title: str
+    menu_path: list[str]
+    content: str
+
+
+def parse_menu_entries(screen: str) -> list[MenuEntry]:
+    """Extract selectable numbered rows from a rendered essence menu."""
+    entries: dict[int, MenuEntry] = {}
+    for line in screen.splitlines():
+        match = MENU_ROW_RE.match(line)
+        if not match:
+            continue
+        index = int(match.group(1))
+        marker = match.group(2)
+        title = match.group(3).strip()
+        if not title or title.startswith(("瀏覽", "說明")):
+            continue
+        entries[index] = MenuEntry(index=index, marker=marker, title=title)
+    return [entries[index] for index in sorted(entries)]
+
+
+def merge_visible_lines(accumulated: list[str], visible: list[str]) -> list[str]:
+    """Merge overlapping terminal pages without repeating retained rows."""
+    if not accumulated:
+        return visible.copy()
+    max_overlap = min(len(accumulated), len(visible))
+    for size in range(max_overlap, 0, -1):
+        if accumulated[-size:] == visible[:size]:
+            return accumulated + visible[size:]
+    return accumulated + visible
+
+
+def _menu_targets() -> list[connect_core.TargetUnit]:
+    return [
+        connect_core.TargetUnit(word, break_detect=True, refresh=False)
+        for word in MENU_WORDS
+    ]
+
+
+def _last_screen(bot: Any) -> str:
+    queue = bot.connect_core.get_screen_queue()
+    return queue[-1] if queue else ""
+
+
+def scan_current_menu(bot: Any, *, max_pages: int = 500) -> list[MenuEntry]:
+    entries: dict[int, MenuEntry] = {}
+    previous_ids: set[int] = set()
+
+    for _ in range(max_pages):
+        screen = _last_screen(bot)
+        for entry in parse_menu_entries(screen):
+            entries[entry.index] = entry
+        current_ids = set(entries)
+
+        if "(100%)" in screen or "（100%）" in screen:
+            break
+        if current_ids == previous_ids and previous_ids:
+            break
+        previous_ids = current_ids.copy()
+
+        result = bot.connect_core.send(
+            command.page_down,
+            _menu_targets(),
+            screen_timeout=3.0,
+            refresh=False,
+        )
+        if result < 0:
+            break
+
+    return [entries[index] for index in sorted(entries)]
+
+
+def _open_entry(bot: Any, index: int) -> str:
+    targets = [
+        connect_core.TargetUnit(
+            screens.Target.InPost, break_detect=True, refresh=False
+        ),
+        *_menu_targets(),
+        connect_core.TargetUnit("任意鍵", response=" ", refresh=False),
+    ]
+    result = bot.connect_core.send(
+        str(index) + command.enter,
+        targets,
+        screen_timeout=5.0,
+        refresh=False,
+    )
+    if result == 0:
+        return "document"
+    if 1 <= result <= len(MENU_WORDS):
+        return "directory"
+    raise RuntimeError(f"Could not classify essence item {index}; match={result}")
+
+
+def _leave_current_item(bot: Any) -> None:
+    bot.connect_core.send(
+        command.left,
+        _menu_targets(),
+        screen_timeout=5.0,
+        refresh=False,
+    )
+
+
+def capture_current_document(bot: Any, *, max_steps: int = 10000) -> str:
+    accumulated: list[str] = []
+
+    for _ in range(max_steps):
+        screen = _last_screen(bot)
+        lines = screen.splitlines()
+        if lines and "瀏覽" in lines[-1] and "頁" in lines[-1]:
+            lines = lines[:-1]
+        while lines and not lines[-1].strip():
+            lines.pop()
+        accumulated = merge_visible_lines(accumulated, lines)
+
+        if "(100%)" in screen or "（100%）" in screen:
+            break
+        result = bot.connect_core.send(
+            command.down,
+            [
+                connect_core.TargetUnit(
+                    screens.Target.PostEnd, break_detect=True, refresh=False
+                ),
+                connect_core.TargetUnit(
+                    screens.Target.InPost, break_detect=True, refresh=False
+                ),
+            ],
+            screen_timeout=5.0,
+            refresh=False,
+        )
+        if result < 0:
+            raise RuntimeError("Timed out while reading an essence document")
+    else:
+        raise RuntimeError("Essence document exceeded the terminal step limit")
+
+    return "\n".join(accumulated).strip()
+
+
+def crawl_essence(
+    bot: Any,
+    board: str,
+    *,
+    max_depth: int = 30,
+    max_documents: int = 0,
+) -> list[EssenceDocument]:
+    """Walk the board's essence tree and return every readable document."""
+    _api_util.goto_board(bot, board, refresh=True)
+    targets = [
+        *_menu_targets(),
+        connect_core.TargetUnit("無精華區", break_detect=True, refresh=False),
+        connect_core.TargetUnit("任意鍵", response=" ", refresh=False),
+    ]
+    result = bot.connect_core.send(
+        "z",
+        targets,
+        screen_timeout=5.0,
+        refresh=False,
+    )
+    if result == len(MENU_WORDS):
+        return []
+    if result < 0:
+        raise RuntimeError("Could not enter the board's essence area")
+
+    documents: list[EssenceDocument] = []
+
+    def walk(menu_path: list[str], depth: int) -> None:
+        if depth > max_depth:
+            raise RuntimeError(f"Essence tree exceeded max depth {max_depth}")
+        entries = scan_current_menu(bot)
+        for entry in entries:
+            if max_documents and len(documents) >= max_documents:
+                return
+            kind = _open_entry(bot, entry.index)
+            if kind == "document":
+                content = capture_current_document(bot)
+                documents.append(
+                    EssenceDocument(
+                        title=entry.title,
+                        menu_path=menu_path.copy(),
+                        content=content,
+                    )
+                )
+                _leave_current_item(bot)
+            else:
+                walk(menu_path + [entry.title], depth + 1)
+                _leave_current_item(bot)
+
+    walk([], 0)
+    return documents

--- a/tools/ptt2-exporter/essence.py
+++ b/tools/ptt2-exporter/essence.py
@@ -171,8 +171,8 @@ def crawl_essence(
     """Walk the board's essence tree and return every readable document."""
     _api_util.goto_board(bot, board, refresh=True)
     targets = [
-        *_menu_targets(),
         connect_core.TargetUnit("無精華區", break_detect=True, refresh=False),
+        *_menu_targets(),
         connect_core.TargetUnit("任意鍵", response=" ", refresh=False),
     ]
     result = bot.connect_core.send(
@@ -181,7 +181,7 @@ def crawl_essence(
         screen_timeout=5.0,
         refresh=False,
     )
-    if result == len(MENU_WORDS):
+    if result == 0:
         return []
     if result < 0:
         raise RuntimeError("Could not enter the board's essence area")

--- a/tools/ptt2-exporter/hugo_export.py
+++ b/tools/ptt2-exporter/hugo_export.py
@@ -1,0 +1,237 @@
+"""Render PTT2 records as reviewable Hugo draft bundles."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def safe_name(value: str, fallback: str = "item") -> str:
+    value = SAFE_NAME_RE.sub("-", value.strip()).strip("-.").lower()
+    return value[:80] or fallback
+
+
+def toml_string(value: Any) -> str:
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def parse_ptt_date(value: Any, fallback: datetime) -> datetime:
+    text = str(value or "").strip()
+    for pattern in (
+        "%a %b %d %H:%M:%S %Y",
+        "%a %b %d %H:%M:%S %z %Y",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d",
+    ):
+        try:
+            parsed = datetime.strptime(text, pattern)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed
+        except ValueError:
+            continue
+    return fallback
+
+
+def fenced_text(value: str) -> str:
+    longest = max((len(match.group(0)) for match in re.finditer(r"`+", value)), default=0)
+    fence = "`" * max(3, longest + 1)
+    return f"{fence}text\n{value.rstrip()}\n{fence}"
+
+
+def _front_matter(fields: list[tuple[str, Any]]) -> str:
+    lines = ["+++"]
+    for key, value in fields:
+        if isinstance(value, bool):
+            rendered = "true" if value else "false"
+        elif isinstance(value, int):
+            rendered = str(value)
+        elif isinstance(value, list):
+            rendered = "[" + ", ".join(toml_string(item) for item in value) + "]"
+        else:
+            rendered = toml_string(value)
+        lines.append(f"{key} = {rendered}")
+    lines.append("+++")
+    return "\n".join(lines)
+
+
+def _base_fields(
+    *, title: str, author: str, date: datetime, board: str, source_kind: str
+) -> list[tuple[str, Any]]:
+    return [
+        ("author", author),
+        ("title", title),
+        ("date", date.isoformat()),
+        ("draft", True),
+        ("tags", ["PTT2", board]),
+        ("categories", ["PTT2 匯入"]),
+        ("summary", f"從 PTT2 {board} 匯入的{source_kind}草稿"),
+        ("showtoc", False),
+        ("tocopen", False),
+        ("ShowReadingTime", False),
+        ("ShowWordCount", False),
+        ("disableShare", False),
+        ("comments", True),
+        ("ptt2_board", board),
+        ("ptt2_source_kind", source_kind),
+    ]
+
+
+def _clean_comment(comment: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": comment.get("type"),
+        "author": comment.get("author"),
+        "content": comment.get("content"),
+        "time": comment.get("time"),
+    }
+
+
+def write_regular_post(
+    post: dict[str, Any],
+    *,
+    board: str,
+    content_root: Path,
+    raw_root: Path,
+    exported_at: datetime,
+) -> dict[str, Any]:
+    index = int(post.get("index") or 0)
+    aid = str(post.get("aid") or "")
+    title = str(post.get("title") or f"PTT2 article {index}")
+    author = str(post.get("author") or "PTT2")
+    date = parse_ptt_date(post.get("date"), exported_at)
+    identifier = safe_name(aid, str(index or "unknown"))
+    stem = f"{date:%Y-%m-%d}-{index:06d}-{identifier}"
+
+    fields = _base_fields(
+        title=title,
+        author=author,
+        date=date,
+        board=board,
+        source_kind="一般文章",
+    )
+    fields.extend(
+        [
+            ("slug", f"ptt2-{safe_name(board)}-{identifier}"),
+            ("ptt2_aid", aid),
+            ("ptt2_index", index),
+        ]
+    )
+
+    content = str(post.get("content") or "")
+    comments = [
+        _clean_comment(item)
+        for item in (post.get("comments") or [])
+        if isinstance(item, dict)
+    ]
+    body = [
+        _front_matter(fields),
+        "",
+        "> 自動匯入的公開 PTT2 內容；預設為草稿，發布前請確認內容與授權。",
+        "",
+        fenced_text(content),
+    ]
+    if comments:
+        body.extend(["", "## 回應", ""])
+        for item in comments:
+            label = " ".join(
+                str(item.get(key) or "").strip()
+                for key in ("type", "author", "time")
+            ).strip()
+            body.append(f"- **{label or '回應'}**：{item.get('content') or ''}")
+
+    content_root.mkdir(parents=True, exist_ok=True)
+    raw_root.mkdir(parents=True, exist_ok=True)
+    markdown_path = content_root / f"{stem}.md"
+    raw_path = raw_root / f"{stem}.json"
+    markdown_path.write_text("\n".join(body).rstrip() + "\n", encoding="utf-8")
+
+    raw_record = {
+        "board": board,
+        "aid": aid,
+        "index": index,
+        "author": author,
+        "title": title,
+        "date": post.get("date"),
+        "list_date": post.get("list_date"),
+        "content": content,
+        "comments": comments,
+        "post_status": post.get("post_status"),
+    }
+    raw_path.write_text(
+        json.dumps(raw_record, ensure_ascii=False, indent=2, default=str) + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "kind": "post",
+        "index": index,
+        "aid": aid,
+        "title": title,
+        "hugo_path": markdown_path.as_posix(),
+        "raw_path": raw_path.as_posix(),
+        "sha256": hashlib.sha256(markdown_path.read_bytes()).hexdigest(),
+    }
+
+
+def write_essence_document(
+    document: Any,
+    *,
+    board: str,
+    sequence: int,
+    content_root: Path,
+    raw_root: Path,
+    exported_at: datetime,
+) -> dict[str, Any]:
+    record = asdict(document) if is_dataclass(document) else dict(document)
+    title = str(record.get("title") or f"精華區文件 {sequence}")
+    text = str(record.get("content") or "")
+    menu_path = [str(item) for item in (record.get("menu_path") or [])]
+    path_key = "/".join(menu_path + [title])
+    digest = hashlib.sha1(path_key.encode("utf-8")).hexdigest()[:12]
+    stem = f"essence-{sequence:05d}-{digest}"
+
+    fields = _base_fields(
+        title=title,
+        author="PTT2 精華區",
+        date=exported_at,
+        board=board,
+        source_kind="精華區文件",
+    )
+    fields.extend(
+        [
+            ("slug", f"ptt2-{safe_name(board)}-{stem}"),
+            ("ptt2_essence_path", " / ".join(menu_path + [title])),
+        ]
+    )
+    body = [
+        _front_matter(fields),
+        "",
+        "> 自動匯入的公開 PTT2 精華區內容；預設為草稿，發布前請確認內容與授權。",
+        "",
+        fenced_text(text),
+    ]
+
+    content_root.mkdir(parents=True, exist_ok=True)
+    raw_root.mkdir(parents=True, exist_ok=True)
+    markdown_path = content_root / f"{stem}.md"
+    raw_path = raw_root / f"{stem}.json"
+    markdown_path.write_text("\n".join(body).rstrip() + "\n", encoding="utf-8")
+    raw_path.write_text(
+        json.dumps(record, ensure_ascii=False, indent=2, default=str) + "\n",
+        encoding="utf-8",
+    )
+    return {
+        "kind": "essence",
+        "title": title,
+        "menu_path": menu_path,
+        "hugo_path": markdown_path.as_posix(),
+        "raw_path": raw_path.as_posix(),
+        "sha256": hashlib.sha256(markdown_path.read_bytes()).hexdigest(),
+    }

--- a/tools/ptt2-exporter/ptt2_client.py
+++ b/tools/ptt2-exporter/ptt2_client.py
@@ -1,0 +1,129 @@
+"""Small read-only PTT2 client helpers built on top of PyPtt."""
+
+from __future__ import annotations
+
+import time
+
+import PyPtt
+from PyPtt import command, connect_core, data_type, exceptions, screens
+
+
+class GuestCapacityError(RuntimeError):
+    """PTT2 has temporarily exhausted its anonymous guest slots."""
+
+
+def make_bot() -> PyPtt.API:
+    return PyPtt.API(
+        host=PyPtt.HOST.PTT2,
+        log_level=PyPtt.LogLevel.INFO,
+        screen_timeout=5.0,
+        screen_long_timeout=20.0,
+        screen_height=100,
+    )
+
+
+def _finish_login_state(bot: PyPtt.API, screen: str, *, registered: bool) -> None:
+    if not all(target in screen for target in screens.Target.MainMenu):
+        raise exceptions.LoginError()
+
+    if "> (" in screen:
+        bot.cursor = data_type.Cursor.NEW
+    elif "●(" in screen:
+        bot.cursor = data_type.Cursor.OLD
+    else:
+        raise exceptions.UnknownError()
+
+    screens.Target.InBoardWithCursor = screens.Target.InBoardWithCursor[
+        : screens.Target.InBoardWithCursorLen
+    ]
+    screens.Target.InBoardWithCursor.append(bot.cursor)
+    screens.Target.InMailBoxWithCursor = screens.Target.InMailBoxWithCursor[
+        : screens.Target.InMailBoxWithCursorLen
+    ]
+    screens.Target.InMailBoxWithCursor.append(bot.cursor)
+
+    bot.is_registered_user = registered
+    bot._is_login = True
+
+
+def login_guest(bot: PyPtt.API) -> None:
+    """Enter PTT2's built-in, read-only guest session.
+
+    PyPtt's registered-account login submits ``account,password``. PTT2's
+    guest account instead enters directly after the account name, so it needs
+    this small protocol adapter.
+    """
+    bot.connect_core.connect()
+    bot.ptt_id = "guest"
+    bot._ptt_pw = ""
+
+    targets = [
+        connect_core.TargetUnit(screens.Target.MainMenu, break_detect=True),
+        connect_core.TargetUnit(
+            "太多 guest",
+            break_detect=True,
+            exceptions_=GuestCapacityError("PTT2 guest capacity is full"),
+        ),
+        connect_core.TargetUnit("【看板列表】", response=command.go_main_menu),
+        connect_core.TargetUnit("登入太頻繁", response=" "),
+        connect_core.TargetUnit("系統過載", break_detect=True),
+        connect_core.TargetUnit("任意鍵", response=" "),
+        connect_core.TargetUnit("【分類看板】", response=command.go_main_menu),
+        connect_core.TargetUnit("熱門話題", response=command.go_main_menu),
+    ]
+    bot.connect_core.send(
+        "guest" + command.enter,
+        targets,
+        screen_timeout=bot.config.screen_long_timeout,
+        refresh=False,
+        secret=True,
+    )
+
+    queue = bot.connect_core.get_screen_queue()
+    screen = queue[-1] if queue else ""
+    _finish_login_state(bot, screen, registered=False)
+
+
+def login_with_retry(
+    ptt_id: str,
+    password: str,
+    *,
+    guest_attempts: int = 4,
+    guest_retry_seconds: int = 20,
+) -> PyPtt.API:
+    """Create and log in a bot, retrying only transient guest-capacity errors."""
+    is_guest = ptt_id.strip().lower() == "guest"
+    attempts = max(1, guest_attempts if is_guest else 1)
+
+    for attempt in range(1, attempts + 1):
+        bot = make_bot()
+        try:
+            if is_guest:
+                login_guest(bot)
+            else:
+                bot.login(
+                    ptt_id=ptt_id,
+                    ptt_pw=password,
+                    kick_other_session=False,
+                )
+            return bot
+        except GuestCapacityError as exc:
+            try:
+                bot.connect_core.close()
+            except Exception:
+                pass
+            if attempt == attempts:
+                raise GuestCapacityError(
+                    "PTT2 guest capacity remained full after "
+                    f"{attempts} attempts. Add PTT2_ID and PTT2_PASSWORD as "
+                    "GitHub Actions secrets, or retry later."
+                ) from exc
+            time.sleep(guest_retry_seconds * attempt)
+        except Exception:
+            try:
+                bot.connect_core.close()
+            except Exception:
+                pass
+            raise
+
+    raise AssertionError("unreachable")

--- a/tools/ptt2-exporter/ptt2_export.py
+++ b/tools/ptt2-exporter/ptt2_export.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Export a public PTT2 board and its essence tree into a Hugo-ready ZIP."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import PyPtt
+
+from essence import crawl_essence
+from hugo_export import write_essence_document, write_regular_post
+from ptt2_client import GuestCapacityError, login_with_retry
+
+
+def fetch_post_list(bot: PyPtt.API, board: str, max_posts: int) -> list[dict[str, Any]]:
+    newest = bot.get_newest_index(PyPtt.NewIndex.BOARD, board=board)
+    wanted = newest if max_posts == 0 else min(newest, max_posts)
+    records: dict[int, dict[str, Any]] = {}
+    offset = 0
+
+    while offset < wanted:
+        limit = min(100, wanted - offset)
+        for item in bot.get_post_list(board=board, limit=limit, offset=offset):
+            index = int(item.get("index") or 0)
+            if index > 0:
+                records[index] = item
+        offset += limit
+
+    return [records[index] for index in sorted(records)]
+
+
+def export_posts(
+    bot: PyPtt.API,
+    board: str,
+    max_posts: int,
+    bundle_root: Path,
+    exported_at: datetime,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    summaries = fetch_post_list(bot, board, max_posts)
+    exported: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+    content_root = bundle_root / "content" / "posts" / "ptt2" / board
+    raw_root = bundle_root / "ptt2-archive" / board / "posts"
+
+    for position, summary in enumerate(summaries, start=1):
+        index = int(summary.get("index") or 0)
+        print(f"[{position}/{len(summaries)}] post index {index}", flush=True)
+        try:
+            post = bot.get_post(board=board, index=index)
+            if not post.get("content"):
+                errors.append(
+                    {"kind": "post", "index": index, "error": "no readable content"}
+                )
+                continue
+            exported.append(
+                write_regular_post(
+                    post,
+                    board=board,
+                    content_root=content_root,
+                    raw_root=raw_root,
+                    exported_at=exported_at,
+                )
+            )
+        except Exception as exc:
+            errors.append(
+                {"kind": "post", "index": index, "error": f"{type(exc).__name__}: {exc}"}
+            )
+        time.sleep(0.05)
+
+    return exported, errors
+
+
+def export_essence(
+    bot: PyPtt.API,
+    board: str,
+    max_documents: int,
+    bundle_root: Path,
+    exported_at: datetime,
+) -> list[dict[str, Any]]:
+    documents = crawl_essence(
+        bot,
+        board,
+        max_documents=max_documents,
+    )
+    content_root = bundle_root / "content" / "posts" / "ptt2" / board / "essence"
+    raw_root = bundle_root / "ptt2-archive" / board / "essence"
+    return [
+        write_essence_document(
+            document,
+            board=board,
+            sequence=sequence,
+            content_root=content_root,
+            raw_root=raw_root,
+            exported_at=exported_at,
+        )
+        for sequence, document in enumerate(documents, start=1)
+    ]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--board", default="InAddition")
+    parser.add_argument("--scope", choices=("both", "posts", "essence"), default="both")
+    parser.add_argument(
+        "--max-posts",
+        type=int,
+        default=0,
+        help="Newest regular posts to export; 0 means all",
+    )
+    parser.add_argument(
+        "--max-essence-documents",
+        type=int,
+        default=0,
+        help="Essence documents to export; 0 means all",
+    )
+    parser.add_argument("--guest-attempts", type=int, default=4)
+    parser.add_argument("--output", default="ptt2-export")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.max_posts < 0 or args.max_essence_documents < 0:
+        raise SystemExit("max values must be zero or positive")
+
+    board = args.board.strip()
+    if not board or not all(char.isalnum() or char in "_-" for char in board):
+        raise SystemExit("board must contain only letters, numbers, '_' or '-'")
+
+    bundle_root = Path(args.output).resolve()
+    bundle_root.mkdir(parents=True, exist_ok=True)
+    exported_at = datetime.now(timezone.utc)
+    ptt_id = os.environ.get("PTT2_ID") or "guest"
+    password = os.environ.get("PTT2_PASSWORD") or ""
+    manifest: dict[str, Any] = {
+        "schema_version": 1,
+        "board": board,
+        "scope": args.scope,
+        "exported_at": exported_at.isoformat(),
+        "login_mode": "guest" if ptt_id.lower() == "guest" else "credential",
+        "draft": True,
+        "items": [],
+        "errors": [],
+    }
+
+    bot = None
+    try:
+        bot = login_with_retry(
+            ptt_id,
+            password,
+            guest_attempts=args.guest_attempts,
+        )
+        if args.scope in ("both", "posts"):
+            posts, errors = export_posts(
+                bot,
+                board,
+                args.max_posts,
+                bundle_root,
+                exported_at,
+            )
+            manifest["items"].extend(posts)
+            manifest["errors"].extend(errors)
+        if args.scope in ("both", "essence"):
+            manifest["items"].extend(
+                export_essence(
+                    bot,
+                    board,
+                    args.max_essence_documents,
+                    bundle_root,
+                    exported_at,
+                )
+            )
+    except GuestCapacityError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    finally:
+        if bot is not None:
+            try:
+                bot.logout()
+            except Exception:
+                pass
+
+    manifest["counts"] = {
+        "posts": sum(item["kind"] == "post" for item in manifest["items"]),
+        "essence": sum(item["kind"] == "essence" for item in manifest["items"]),
+        "errors": len(manifest["errors"]),
+    }
+    (bundle_root / "manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, default=str) + "\n",
+        encoding="utf-8",
+    )
+    shutil.make_archive(str(bundle_root), "zip", root_dir=bundle_root)
+    print(f"Exported bundle: {bundle_root}.zip")
+    print(json.dumps(manifest["counts"], ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ptt2-exporter/ptt2_export.py
+++ b/tools/ptt2-exporter/ptt2_export.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import sys
 import time
@@ -18,6 +19,21 @@ import PyPtt
 from essence import crawl_essence
 from hugo_export import write_essence_document, write_regular_post
 from ptt2_client import GuestCapacityError, login_with_retry
+
+
+IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+
+
+def sanitize_error(value: str) -> str:
+    value = IPV4_RE.sub("[redacted-ip]", value)
+    return EMAIL_RE.sub("[redacted-email]", value)
+
+
+def make_paths_portable(record: dict[str, Any], bundle_root: Path) -> dict[str, Any]:
+    for key in ("hugo_path", "raw_path"):
+        record[key] = Path(record[key]).relative_to(bundle_root).as_posix()
+    return record
 
 
 def fetch_post_list(bot: PyPtt.API, board: str, max_posts: int) -> list[dict[str, Any]]:
@@ -61,17 +77,24 @@ def export_posts(
                 )
                 continue
             exported.append(
-                write_regular_post(
-                    post,
-                    board=board,
-                    content_root=content_root,
-                    raw_root=raw_root,
-                    exported_at=exported_at,
+                make_paths_portable(
+                    write_regular_post(
+                        post,
+                        board=board,
+                        content_root=content_root,
+                        raw_root=raw_root,
+                        exported_at=exported_at,
+                    ),
+                    bundle_root,
                 )
             )
         except Exception as exc:
             errors.append(
-                {"kind": "post", "index": index, "error": f"{type(exc).__name__}: {exc}"}
+                {
+                    "kind": "post",
+                    "index": index,
+                    "error": sanitize_error(f"{type(exc).__name__}: {exc}"),
+                }
             )
         time.sleep(0.05)
 
@@ -93,13 +116,16 @@ def export_essence(
     content_root = bundle_root / "content" / "posts" / "ptt2" / board / "essence"
     raw_root = bundle_root / "ptt2-archive" / board / "essence"
     return [
-        write_essence_document(
-            document,
-            board=board,
-            sequence=sequence,
-            content_root=content_root,
-            raw_root=raw_root,
-            exported_at=exported_at,
+        make_paths_portable(
+            write_essence_document(
+                document,
+                board=board,
+                sequence=sequence,
+                content_root=content_root,
+                raw_root=raw_root,
+                exported_at=exported_at,
+            ),
+            bundle_root,
         )
         for sequence, document in enumerate(documents, start=1)
     ]

--- a/tools/ptt2-exporter/ptt2_probe.py
+++ b/tools/ptt2-exporter/ptt2_probe.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Read-only connectivity and screen probe for a public PTT2 board."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Any
+
+import PyPtt
+from PyPtt import _api_util, connect_core
+
+
+IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+
+
+def sanitize(value: str) -> str:
+    """Keep structural diagnostics while removing incidental personal data."""
+    value = IPV4_RE.sub("[redacted-ip]", value)
+    return EMAIL_RE.sub("[redacted-email]", value)
+
+
+def capture_essence_root(bot: PyPtt.API, board: str) -> dict[str, Any]:
+    """Enter the board's z-menu and capture the rendered root screen.
+
+    PyPtt does not currently expose a public API for the man/essence tree, so
+    this probe deliberately uses its terminal core. The captured screen is
+    used to build and verify a board-compatible state machine in the exporter.
+    """
+    _api_util.goto_board(bot, board, refresh=True)
+
+    targets = [
+        connect_core.TargetUnit("精華區", break_detect=True, refresh=False),
+        connect_core.TargetUnit("目錄", break_detect=True, refresh=False),
+        connect_core.TargetUnit("主題", break_detect=True, refresh=False),
+        connect_core.TargetUnit("無精華區", break_detect=True, refresh=False),
+        connect_core.TargetUnit("任意鍵", response=" ", refresh=False),
+    ]
+
+    result = bot.connect_core.send(
+        "z",
+        targets,
+        screen_timeout=5.0,
+        refresh=False,
+    )
+
+    queue = bot.connect_core.get_screen_queue()
+    screen = queue[-1] if queue else ""
+    return {
+        "match_index": result,
+        "screen": sanitize(screen),
+    }
+
+
+def probe(board: str) -> dict[str, Any]:
+    ptt_id = os.environ.get("PTT2_ID") or "guest"
+    ptt_password = os.environ.get("PTT2_PASSWORD") or ""
+
+    bot = PyPtt.API(
+        host=PyPtt.HOST.PTT2,
+        log_level=PyPtt.LogLevel.INFO,
+        screen_timeout=5.0,
+        screen_long_timeout=15.0,
+        screen_height=100,
+    )
+
+    report: dict[str, Any] = {
+        "board": board,
+        "login_mode": "credential" if ptt_id.lower() != "guest" else "guest",
+        "host": "PTT2",
+    }
+
+    try:
+        bot.login(ptt_id=ptt_id, ptt_pw=ptt_password, kick_other_session=False)
+        report["login"] = "ok"
+
+        newest = bot.get_newest_index(PyPtt.NewIndex.BOARD, board=board)
+        report["newest_index"] = newest
+
+        if newest > 0:
+            sample_size = min(3, newest)
+            report["latest_posts"] = bot.get_post_list(
+                board=board,
+                limit=sample_size,
+                offset=0,
+            )
+        else:
+            report["latest_posts"] = []
+
+        report["essence_root"] = capture_essence_root(bot, board)
+        report["status"] = "ok"
+        return report
+    except Exception as exc:  # diagnostics must include the concrete failure
+        report["status"] = "error"
+        report["error_type"] = type(exc).__name__
+        report["error"] = sanitize(str(exc))
+        return report
+    finally:
+        try:
+            bot.logout()
+        except Exception:
+            pass
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--board", default="InAddition")
+    parser.add_argument("--output", default="ptt2-probe.json")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    report = probe(args.board)
+    payload = json.dumps(report, ensure_ascii=False, indent=2, default=str)
+    with open(args.output, "w", encoding="utf-8") as output_file:
+        output_file.write(payload + "\n")
+    print(payload)
+    return 0 if report.get("status") == "ok" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ptt2-exporter/ptt2_probe.py
+++ b/tools/ptt2-exporter/ptt2_probe.py
@@ -11,7 +11,9 @@ import sys
 from typing import Any
 
 import PyPtt
-from PyPtt import _api_util, command, connect_core, data_type, exceptions, screens
+from PyPtt import _api_util, connect_core
+
+from ptt2_client import login_with_retry
 
 
 IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
@@ -22,62 +24,6 @@ def sanitize(value: str) -> str:
     """Keep structural diagnostics while removing incidental personal data."""
     value = IPV4_RE.sub("[redacted-ip]", value)
     return EMAIL_RE.sub("[redacted-email]", value)
-
-
-def login_guest(bot: PyPtt.API) -> None:
-    """Log in to PTT2's read-only guest session.
-
-    PyPtt always submits ``account,password`` because registered accounts use
-    that protocol.  PTT2's built-in guest account is different: it enters the
-    main menu immediately after ``guest`` and never asks for a password.
-    """
-    bot.connect_core.connect()
-    bot.ptt_id = "guest"
-    bot._ptt_pw = ""
-
-    targets = [
-        connect_core.TargetUnit(screens.Target.MainMenu, break_detect=True),
-        connect_core.TargetUnit("【看板列表】", response=command.go_main_menu),
-        connect_core.TargetUnit("登入太頻繁", response=" "),
-        connect_core.TargetUnit("系統過載", break_detect=True),
-        connect_core.TargetUnit("任意鍵", response=" "),
-        connect_core.TargetUnit("【分類看板】", response=command.go_main_menu),
-        connect_core.TargetUnit("熱門話題", response=command.go_main_menu),
-    ]
-    bot.connect_core.send(
-        "guest" + command.enter,
-        targets,
-        screen_timeout=bot.config.screen_long_timeout,
-        refresh=False,
-        secret=True,
-    )
-
-    queue = bot.connect_core.get_screen_queue()
-    screen = queue[-1] if queue else ""
-    if not all(target in screen for target in screens.Target.MainMenu):
-        raise RuntimeError(
-            "guest login did not reach the main menu; final screen:\n"
-            + sanitize(screen)
-        )
-
-    if "> (" in screen:
-        bot.cursor = data_type.Cursor.NEW
-    elif "●(" in screen:
-        bot.cursor = data_type.Cursor.OLD
-    else:
-        raise exceptions.UnknownError()
-
-    screens.Target.InBoardWithCursor = screens.Target.InBoardWithCursor[
-        : screens.Target.InBoardWithCursorLen
-    ]
-    screens.Target.InBoardWithCursor.append(bot.cursor)
-    screens.Target.InMailBoxWithCursor = screens.Target.InMailBoxWithCursor[
-        : screens.Target.InMailBoxWithCursorLen
-    ]
-    screens.Target.InMailBoxWithCursor.append(bot.cursor)
-
-    bot.is_registered_user = False
-    bot._is_login = True
 
 
 def capture_essence_root(bot: PyPtt.API, board: str) -> dict[str, Any]:
@@ -116,25 +62,15 @@ def probe(board: str) -> dict[str, Any]:
     ptt_id = os.environ.get("PTT2_ID") or "guest"
     ptt_password = os.environ.get("PTT2_PASSWORD") or ""
 
-    bot = PyPtt.API(
-        host=PyPtt.HOST.PTT2,
-        log_level=PyPtt.LogLevel.INFO,
-        screen_timeout=5.0,
-        screen_long_timeout=15.0,
-        screen_height=100,
-    )
-
     report: dict[str, Any] = {
         "board": board,
         "login_mode": "credential" if ptt_id.lower() != "guest" else "guest",
         "host": "PTT2",
     }
 
+    bot = None
     try:
-        if ptt_id.lower() == "guest":
-            login_guest(bot)
-        else:
-            bot.login(ptt_id=ptt_id, ptt_pw=ptt_password, kick_other_session=False)
+        bot = login_with_retry(ptt_id, ptt_password, guest_attempts=1)
         report["login"] = "ok"
 
         newest = bot.get_newest_index(PyPtt.NewIndex.BOARD, board=board)
@@ -159,10 +95,11 @@ def probe(board: str) -> dict[str, Any]:
         report["error"] = sanitize(str(exc))
         return report
     finally:
-        try:
-            bot.logout()
-        except Exception:
-            pass
+        if bot is not None:
+            try:
+                bot.logout()
+            except Exception:
+                pass
 
 
 def parse_args() -> argparse.Namespace:

--- a/tools/ptt2-exporter/ptt2_probe.py
+++ b/tools/ptt2-exporter/ptt2_probe.py
@@ -11,7 +11,7 @@ import sys
 from typing import Any
 
 import PyPtt
-from PyPtt import _api_util, connect_core
+from PyPtt import _api_util, command, connect_core, data_type, exceptions, screens
 
 
 IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
@@ -22,6 +22,59 @@ def sanitize(value: str) -> str:
     """Keep structural diagnostics while removing incidental personal data."""
     value = IPV4_RE.sub("[redacted-ip]", value)
     return EMAIL_RE.sub("[redacted-email]", value)
+
+
+def login_guest(bot: PyPtt.API) -> None:
+    """Log in to PTT2's read-only guest session.
+
+    PyPtt always submits ``account,password`` because registered accounts use
+    that protocol.  PTT2's built-in guest account is different: it enters the
+    main menu immediately after ``guest`` and never asks for a password.
+    """
+    bot.connect_core.connect()
+    bot.ptt_id = "guest"
+    bot._ptt_pw = ""
+
+    targets = [
+        connect_core.TargetUnit(screens.Target.MainMenu, break_detect=True),
+        connect_core.TargetUnit("【看板列表】", response=command.go_main_menu),
+        connect_core.TargetUnit("登入太頻繁", response=" "),
+        connect_core.TargetUnit("系統過載", break_detect=True),
+        connect_core.TargetUnit("任意鍵", response=" "),
+        connect_core.TargetUnit("【分類看板】", response=command.go_main_menu),
+        connect_core.TargetUnit("熱門話題", response=command.go_main_menu),
+    ]
+    bot.connect_core.send(
+        "guest" + command.enter,
+        targets,
+        screen_timeout=bot.config.screen_long_timeout,
+        refresh=False,
+        secret=True,
+    )
+
+    queue = bot.connect_core.get_screen_queue()
+    screen = queue[-1] if queue else ""
+    if not all(target in screen for target in screens.Target.MainMenu):
+        raise exceptions.LoginError()
+
+    if "> (" in screen:
+        bot.cursor = data_type.Cursor.NEW
+    elif "●(" in screen:
+        bot.cursor = data_type.Cursor.OLD
+    else:
+        raise exceptions.UnknownError()
+
+    screens.Target.InBoardWithCursor = screens.Target.InBoardWithCursor[
+        : screens.Target.InBoardWithCursorLen
+    ]
+    screens.Target.InBoardWithCursor.append(bot.cursor)
+    screens.Target.InMailBoxWithCursor = screens.Target.InMailBoxWithCursor[
+        : screens.Target.InMailBoxWithCursorLen
+    ]
+    screens.Target.InMailBoxWithCursor.append(bot.cursor)
+
+    bot.is_registered_user = False
+    bot._is_login = True
 
 
 def capture_essence_root(bot: PyPtt.API, board: str) -> dict[str, Any]:
@@ -75,7 +128,10 @@ def probe(board: str) -> dict[str, Any]:
     }
 
     try:
-        bot.login(ptt_id=ptt_id, ptt_pw=ptt_password, kick_other_session=False)
+        if ptt_id.lower() == "guest":
+            login_guest(bot)
+        else:
+            bot.login(ptt_id=ptt_id, ptt_pw=ptt_password, kick_other_session=False)
         report["login"] = "ok"
 
         newest = bot.get_newest_index(PyPtt.NewIndex.BOARD, board=board)

--- a/tools/ptt2-exporter/ptt2_probe.py
+++ b/tools/ptt2-exporter/ptt2_probe.py
@@ -55,7 +55,10 @@ def login_guest(bot: PyPtt.API) -> None:
     queue = bot.connect_core.get_screen_queue()
     screen = queue[-1] if queue else ""
     if not all(target in screen for target in screens.Target.MainMenu):
-        raise exceptions.LoginError()
+        raise RuntimeError(
+            "guest login did not reach the main menu; final screen:\n"
+            + sanitize(screen)
+        )
 
     if "> (" in screen:
         bot.cursor = data_type.Cursor.NEW

--- a/tools/ptt2-exporter/requirements.txt
+++ b/tools/ptt2-exporter/requirements.txt
@@ -1,0 +1,2 @@
+PyPtt @ git+https://github.com/PyPtt/PyPtt.git@b06e3613b70f55ccfc573b8b963b5a53e4a1ca6e
+

--- a/tools/ptt2-exporter/tests/test_essence.py
+++ b/tools/ptt2-exporter/tests/test_essence.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(MODULE_DIR))
+
+# Parser tests do not need a network client. Supply the minimal import surface
+# so they can run even before PyPtt is installed in a local development shell.
+if "PyPtt" not in sys.modules:
+    pyptt = types.ModuleType("PyPtt")
+    pyptt._api_util = object()
+    pyptt.command = types.SimpleNamespace()
+    pyptt.connect_core = types.SimpleNamespace(TargetUnit=object)
+    pyptt.screens = types.SimpleNamespace()
+    sys.modules["PyPtt"] = pyptt
+
+from essence import merge_visible_lines, parse_menu_entries  # noqa: E402
+
+
+class EssenceParserTests(unittest.TestCase):
+    def test_parses_numbered_menu_rows(self) -> None:
+        screen = """
+【InAddition 精華區】
+>   1. ◆ 公告與說明
+    2. ◇ 第一篇文章
+   18. ◎ 舊目錄
+(q)離開
+"""
+        entries = parse_menu_entries(screen)
+        self.assertEqual([entry.index for entry in entries], [1, 2, 18])
+        self.assertEqual(entries[1].title, "第一篇文章")
+
+    def test_merges_scrolled_terminal_windows(self) -> None:
+        first = ["a", "b", "c"]
+        second = ["b", "c", "d"]
+        self.assertEqual(merge_visible_lines(first, second), ["a", "b", "c", "d"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ptt2-exporter/tests/test_exporter.py
+++ b/tools/ptt2-exporter/tests/test_exporter.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(MODULE_DIR))
+
+from hugo_export import fenced_text, write_regular_post  # noqa: E402
+
+
+class HugoExportTests(unittest.TestCase):
+    def test_fence_expands_past_content_backticks(self) -> None:
+        rendered = fenced_text("hello ``` embedded")
+        self.assertTrue(rendered.startswith("````text\n"))
+        self.assertTrue(rendered.endswith("\n````"))
+
+    def test_regular_post_is_draft_and_drops_ip_fields(self) -> None:
+        post = {
+            "index": 42,
+            "aid": "1Ab_CdEf",
+            "author": "writer (Writer)",
+            "title": "測試文章",
+            "date": "Wed Aug 26 12:34:56 2026",
+            "content": "正文",
+            "ip": "192.0.2.1",
+            "comments": [
+                {
+                    "type": "推",
+                    "author": "reader",
+                    "content": "收到",
+                    "time": "08/26 13:00",
+                    "ip": "198.51.100.2",
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            result = write_regular_post(
+                post,
+                board="InAddition",
+                content_root=root / "content",
+                raw_root=root / "raw",
+                exported_at=datetime(2026, 8, 26, tzinfo=timezone.utc),
+            )
+            markdown = Path(result["hugo_path"]).read_text(encoding="utf-8")
+            raw = Path(result["raw_path"]).read_text(encoding="utf-8")
+            self.assertIn("draft = true", markdown)
+            self.assertIn('ptt2_board = "InAddition"', markdown)
+            self.assertIn("測試文章", markdown)
+            self.assertNotIn("192.0.2.1", markdown + raw)
+            self.assertNotIn("198.51.100.2", markdown + raw)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Add a read-only, online exporter for public PTT2 boards, initially configured for `InAddition`. It downloads regular posts and the recursive `z` essence tree, then produces a Hugo/PaperMod-ready ZIP for this site.

## Included

- GitHub Actions **Run workflow** form with board, scope, and item-limit inputs
- PTT2 WebSocket client with registered-account and retrying guest modes
- regular-post export through PyPtt's read API
- recursive terminal state machine for the PTT2 essence tree
- Hugo TOML front matter matching this repository
- `draft = true` on every imported page
- IP-free structured JSON archive and a SHA-256 manifest
- offline tests for menu parsing, terminal-page merging, Markdown fencing, and privacy behavior
- Traditional Chinese usage and Actions Secrets instructions

## Validation

- GitHub-hosted Actions can establish a WebSocket connection to PTT2.
- The repository's Hugo/Pages build passes.
- The exporter compile and offline test workflow passes.
- The current anonymous live probe is refused by PTT2 because its guest slots are full. The exporter retries automatically and gives a clear instruction to set `PTT2_ID` / `PTT2_PASSWORD` as repository Actions secrets or retry later.

No PTT2 content is committed or auto-published. The generated ZIP is retained as an Actions artifact for 30 days, and imported pages remain drafts until manually reviewed.