### PR TITLE
Link notes back to their topics, and tag the Archives entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,8 +94,8 @@ front matter 裡 `topics = ["Philosophy"]`，可複選（一則筆記可同時�
 `/topics/` 那頁是 Hugo 自動產生的詞條總覽，但**只列出已經有筆記的議題**，
 所以完整的議題入口是 `/research-notes/` 頁面上那一行，不是 `/topics/`。
 
-已知的小缺口：PaperMod 的單篇頁只渲染 `tags` 的 chip，所以從一則筆記點不回它的議題頁。
-要補的話得覆寫 section 專屬的 single.html，目前判斷不值得。
+筆記的單篇頁底下會顯示議題 chip，點得回議題頁 —— 這是靠
+`layouts/research-notes/single.html` 做的，見下面「覆寫過的主題模板」。
 
 各處的行為（都實際建置驗證過）：
 
@@ -151,6 +151,28 @@ PaperMod 的深色模式靠 JS 在 `<body>` 加 `.dark` class。JS 停用時，�
 - `go.mod` 要求 Go 1.25.1，CI 的 `setup-go` 也設 `1.25.x`。兩邊要對齊，否則每次 build 會多下載一次 toolchain
 - 本機：`hugo mod tidy && hugo server`
 - CI：`.github/workflows/hugo.yml`。push 到 `main` → build + deploy；`pull_request` → 只 build 不部署
+
+## 覆寫過的主題模板
+
+repo 裡有兩份從 PaperMod 複製出來、加了東西的版型。兩份都是**整份複製**，
+所以**升級主題時要回去比對原始檔有沒有變動**，否則會停在舊版：
+
+| 檔案 | 從哪複製 | 多了什麼 | 影響範圍 |
+|---|---|---|---|
+| `layouts/research-notes/single.html` | `_default/single.html` | 議題 chip（`.GetTerms "topics"`） | 只有筆記單篇頁 |
+| `layouts/_default/archives.html` | 同名 | 每篇文章的標籤列 | 只有 `/archives/` 那一頁 |
+
+兩份都刻意選了影響範圍最小的掛法：前者掛在 section 底下，動不到文章頁；
+後者只有 `content/archives.md`（`layout: archives`）會用到。
+
+**注意 `_default/archives.html` 可以覆寫，但 `_default/list.html` 不行** ——
+前者只服務 archives 那一頁，後者會取代所有列表頁（首頁、tags、categories…）。
+
+### Archives 標籤列的坑
+
+PaperMod 的 `.archive-entry` 裡有一個絕對定位、覆蓋整格的 `.entry-link`（點哪裡都進文章）。
+標籤連結必須 `position: relative; z-index: 1` 疊上去，否則**看得到但點不到**，
+點下去會變成進文章。樣式在 `assets/css/extended/archive-tags.css`，那裡有註解。
 
 ## 不要做的事
 

--- a/assets/css/extended/archive-tags.css
+++ b/assets/css/extended/archive-tags.css
@@ -1,0 +1,34 @@
+/* =============================================================
+   Archives 每篇文章底下的標籤列
+
+   刻意做得不起眼：小字、次要色，沒有 chip 底色 —— Archives 是
+   時間軸，標籤是輔助資訊，不該跟標題搶。
+   ============================================================= */
+
+.archive-tags {
+    /* PaperMod 的 .archive-entry 裡有一個絕對定位、覆蓋整格的
+       .entry-link（點哪裡都會進文章）。標籤必須疊在它上面，
+       否則點標籤會變成點進文章。 */
+    position: relative;
+    z-index: 1;
+
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px 12px;
+    margin-top: 6px;
+    font-size: 13px;
+    line-height: 1.8;
+    letter-spacing: 0.02em;
+}
+
+.archive-tags a {
+    color: var(--secondary);
+    /* 只有 hover 時才有下底線，平常安靜地待著 */
+    border-bottom: 1px solid transparent;
+    transition: color 0.12s, border-color 0.12s;
+}
+
+.archive-tags a:hover {
+    color: var(--primary);
+    border-bottom-color: var(--tertiary);
+}

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -1,0 +1,95 @@
+{{- /* 複製自 PaperMod 的 _default/archives.html，只多了每篇的標籤列。
+       只影響 /archives/ 那一頁（content/archives.md 指定 layout: archives）。
+       升級主題時若 archives.html 有變動，這份要跟著更新。 */ -}}
+{{- define "main" }}
+
+<header class="page-header">
+  <h1>
+    {{ .Title }}
+    {{- if (.Param "ShowRssButtonInSectionTermList") }}
+    {{- $rss := (.OutputFormats.Get "rss") }}
+    {{- if (eq .Kind `page`) }}
+    {{- $rss = (.Parent.OutputFormats.Get "rss") }}
+    {{- end }}
+    {{- with $rss }}
+    <a href="{{ .RelPermalink }}" title="RSS" aria-label="RSS">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+        stroke-linecap="round" stroke-linejoin="round" height="23">
+        <path d="M4 11a9 9 0 0 1 9 9" />
+        <path d="M4 4a16 16 0 0 1 16 16" />
+        <circle cx="5" cy="19" r="1" />
+      </svg>
+    </a>
+    {{- end }}
+    {{- end }}
+  </h1>
+  {{- if .Description }}
+  <div class="post-description">
+    {{ .Description }}
+  </div>
+  {{- end }}
+</header>
+
+{{- $pages := where site.RegularPages "Type" "in" site.Params.mainSections }}
+
+{{- if site.Params.ShowAllPagesInArchive }}
+{{- $pages = site.RegularPages }}
+{{- end }}
+
+{{- range $pages.GroupByPublishDate "2006" }}
+{{- if ne .Key "0001" }}
+<div class="archive-year">
+  {{- $year := replace .Key "0001" "" }}
+  <h2 class="archive-year-header" id="{{ $year }}">
+    <a class="archive-header-link" href="#{{ $year }}">
+      {{- $year -}}
+    </a>
+    <sup class="archive-count">&nbsp;{{ len .Pages }}</sup>
+  </h2>
+  {{- range .Pages.GroupByDate "January" }}
+  <div class="archive-month">
+    <h3 class="archive-month-header" id="{{ $year }}-{{ .Key }}">
+      <a class="archive-header-link" href="#{{ $year }}-{{ .Key }}">
+        {{- .Key -}}
+      </a>
+      <sup class="archive-count">&nbsp;{{ len .Pages }}</sup>
+    </h3>
+    <div class="archive-posts">
+      {{- range .Pages }}
+      {{- if eq .Kind "page" }}
+      <div class="archive-entry">
+        <h3 class="archive-entry-title entry-hint-parent">
+          {{- .Title | markdownify }}
+          {{- if .Draft }}
+          <span class="entry-hint" title="Draft">
+            <svg xmlns="http://www.w3.org/2000/svg" height="15" viewBox="0 -960 960 960" fill="currentColor">
+              <path
+                d="M160-410v-60h300v60H160Zm0-165v-60h470v60H160Zm0-165v-60h470v60H160Zm360 580v-123l221-220q9-9 20-13t22-4q12 0 23 4.5t20 13.5l37 37q9 9 13 20t4 22q0 11-4.5 22.5T862.09-380L643-160H520Zm300-263-37-37 37 37ZM580-220h38l121-122-18-19-19-18-122 121v38Zm141-141-19-18 37 37-18-19Z" />
+            </svg>
+          </span>
+          {{- end }}
+        </h3>
+        <div class="archive-meta">
+          {{- partial "post_meta.html" . -}}
+        </div>
+        {{- /* 標籤列。必須疊在下面那個覆蓋整格的 .entry-link 之上，
+               否則點到的會是整篇文章而不是標籤 —— CSS 有 z-index 處理。 */}}
+        {{- with .GetTerms "tags" }}
+        <div class="archive-tags">
+          {{- range . }}
+          <a href="{{ .Permalink }}">{{ .LinkTitle }}</a>
+          {{- end }}
+        </div>
+        {{- end }}
+        <a class="entry-link" aria-label="post link to {{ .Title | plainify }}" href="{{ .Permalink }}"></a>
+      </div>
+      {{- end }}
+      {{- end }}
+    </div>
+  </div>
+  {{- end }}
+</div>
+{{- end }}
+{{- end }}
+
+{{- end }}{{/* end main */}}

--- a/layouts/research-notes/single.html
+++ b/layouts/research-notes/single.html
@@ -1,0 +1,77 @@
+{{- /* ResearchNotes 專用的單篇版型：複製自 PaperMod 的 _default/single.html，
+       只多了下面那段議題 chip。因為只掛在這個 section，動不到文章頁。
+       升級主題時若 single.html 有變動，這份要跟著更新。 */ -}}
+{{- define "main" }}
+
+<article class="post-single">
+  <header class="post-header">
+    {{ partial "breadcrumbs.html" . }}
+    <h1 class="post-title entry-hint-parent">
+      {{ .Title }}
+      {{- if .Draft }}
+      <span class="entry-hint" title="Draft">
+        <svg xmlns="http://www.w3.org/2000/svg" height="35" viewBox="0 -960 960 960" fill="currentColor">
+          <path
+            d="M160-410v-60h300v60H160Zm0-165v-60h470v60H160Zm0-165v-60h470v60H160Zm360 580v-123l221-220q9-9 20-13t22-4q12 0 23 4.5t20 13.5l37 37q9 9 13 20t4 22q0 11-4.5 22.5T862.09-380L643-160H520Zm300-263-37-37 37 37ZM580-220h38l121-122-18-19-19-18-122 121v38Zm141-141-19-18 37 37-18-19Z" />
+        </svg>
+      </span>
+      {{- end }}
+    </h1>
+    {{- if .Description }}
+    <div class="post-description">
+      {{ .Description }}
+    </div>
+    {{- end }}
+    {{- if not (.Param "hideMeta") }}
+    <div class="post-meta">
+      {{- partial "post_meta.html" . -}}
+      {{- partial "translation_list.html" . -}}
+      {{- partial "edit_post.html" . -}}
+      {{- partial "post_canonical.html" . -}}
+    </div>
+    {{- end }}
+  </header>
+  {{- $isHidden := (.Param "cover.hiddenInSingle") | default (.Param "cover.hidden") | default false }}
+  {{- partial "cover.html" (dict "cxt" . "IsSingle" true "isHidden" $isHidden) }}
+  {{- if (.Param "ShowToc") }}
+  {{- partial "toc.html" . }}
+  {{- end }}
+
+  {{- if .Content }}
+  <div class="post-content">
+    {{- if not (.Param "disableAnchoredHeadings") }}
+    {{- partial "anchored_headings.html" .Content -}}
+    {{- else }}{{ .Content }}{{ end }}
+  </div>
+  {{- end }}
+
+  <footer class="post-footer">
+    {{- /* 議題 chip。PaperMod 的單篇頁只渲染 tags，撈不到自訂的 topics
+           taxonomy，所以這個 section 覆寫一份自己的 single.html 補上。 */}}
+    {{- with .GetTerms "topics" }}
+    <ul class="post-tags">
+      {{- range . }}
+      <li><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>
+      {{- end }}
+    </ul>
+    {{- end }}
+    {{- $tags := .Language.Params.Taxonomies.tag | default "tags" }}
+    <ul class="post-tags">
+      {{- range ($.GetTerms $tags) }}
+      <li><a href="{{ .Permalink }}">{{ .LinkTitle }}</a></li>
+      {{- end }}
+    </ul>
+    {{- if (.Param "ShowPostNavLinks") }}
+    {{- partial "post_nav_links.html" . }}
+    {{- end }}
+    {{- if (and site.Params.ShowShareButtons (ne .Params.disableShare true)) }}
+    {{- partial "share_icons.html" . -}}
+    {{- end }}
+  </footer>
+
+  {{- if (.Param "comments") }}
+  {{- partial "comments.html" . }}
+  {{- end }}
+</article>
+
+{{- end }}{{/* end main */}}


### PR DESCRIPTION
兩個導覽缺口，各覆寫一份模板補上。

## 1. 筆記可以回到議題頁

筆記單篇頁底下現在會出現議題 chip（跟文章的標籤 chip 同一種樣式），點下去到 `/topics/philosophy/`。

PaperMod 的單篇版型只渲染 `tags`，撈不到自訂的 `topics`，所以複製一份 `layouts/research-notes/single.html` 加上去。**掛在 section 底下，動不到文章頁** —— 實測確認文章頁仍然只有 tags、沒冒出 topics。

## 2. Archives 顯示標籤，可點

每篇的日期下方多一行標籤，點下去到該標籤的列表頁。

做得刻意不起眼：**小字、次要色、沒有 chip 底色**。Archives 是時間軸，標籤是輔助，不該跟標題搶。

## 一個會讓這件事默默失敗的坑

PaperMod 的 `.archive-entry` 裡有一個**絕對定位、覆蓋整格的 `.entry-link`**（設計上是讓你點該列任何位置都進文章）。標籤連結加進去之後會被它蓋住 —— **看得到、但點下去進的是文章而不是標籤頁**。

CSS 裡用 `position: relative; z-index: 1` 把標籤抬到覆蓋層之上。

這種東西看截圖看不出來，所以我用瀏覽器實際點：

```
標籤座標上最上層的元素: {"hit":"A","isTheTag":true}
點「Memory」    → /tags/memory/
點議題「Philosophy」→ /topics/philosophy/
```

## 兩份模板都是整份複製

這是代價，記在 `CLAUDE.md` 裡了：**升級 PaperMod 時要回去比對原始檔有沒有變動**，否則會停在舊版。

兩份都挑了影響範圍最小的掛法。`CLAUDE.md` 也寫明一個容易搞混的區別：**`_default/archives.html` 可以覆寫（只服務 archives 那一頁），但 `_default/list.html` 不行（會取代所有列表頁，首頁會消失）。**

## 驗證

實際建置＋瀏覽器操作確認：議題 chip 與來源連結同時正常、跨議題筆記兩個 chip 都在、Archives 標籤點得到、文章單篇頁完全沒受影響、筆記沒混進 Archives。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsfDJnA5owdQP8n9Hima2D

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsfDJnA5owdQP8n9Hima2D)_